### PR TITLE
Фикс канала Ботов

### DIFF
--- a/Resources/Prototypes/ADT/Drones/Drone-Engineer/Entities/Mobs/Player/engineeringdrone.yml
+++ b/Resources/Prototypes/ADT/Drones/Drone-Engineer/Entities/Mobs/Player/engineeringdrone.yml
@@ -10,12 +10,12 @@
       - id: WelderExperimental
   - type: IntrinsicRadioTransmitter
     channels:
-    - Botic
+    - ADTSilicon
     - Common
     - Engineering
   - type: ActiveRadio
     channels:
-    - Botic
+    - ADTSilicon
     - Common
     - Engineering
   - type: IntrinsicRadioReceiver

--- a/Resources/Prototypes/ADT/Drones/Drone-Medical/Entities/Mobs/Player/medicaldrone.yml
+++ b/Resources/Prototypes/ADT/Drones/Drone-Medical/Entities/Mobs/Player/medicaldrone.yml
@@ -13,12 +13,12 @@
     channels:
     - Common
     - Medical
-    - Botic
+    - ADTSilicon
   - type: ActiveRadio
     channels:
     - Common
     - Medical
-    - Botic
+    - ADTSilicon
   - type: IntrinsicRadioReceiver
   - type: Access
     tags:

--- a/Resources/Prototypes/ADT/Drones/Drone-Service/Entities/Mobs/Player/servicedrone.yml
+++ b/Resources/Prototypes/ADT/Drones/Drone-Service/Entities/Mobs/Player/servicedrone.yml
@@ -11,12 +11,12 @@
     channels:
     - Common
     - Service
-    - Botic
+    - ADTSilicon
   - type: ActiveRadio
     channels:
     - Common
     - Service
-    - Botic
+    - ADTSilicon
   - type: IntrinsicRadioReceiver
   - type: Access
     tags:

--- a/Resources/Prototypes/ADT/Drones/Foodbot/Entities/Mobs/Player/servicedrone.yml
+++ b/Resources/Prototypes/ADT/Drones/Foodbot/Entities/Mobs/Player/servicedrone.yml
@@ -8,12 +8,12 @@
     channels:
     - Common
     - Service
-    - Botic
+    - ADTSilicon
   - type: ActiveRadio
     channels:
     - Common
     - Service
-    - Botic
+    - ADTSilicon
   - type: IntrinsicRadioReceiver
   - type: Access
     tags:

--- a/Resources/Prototypes/ADT/KD/Channels/Channels/RoboticChannel.yml
+++ b/Resources/Prototypes/ADT/KD/Channels/Channels/RoboticChannel.yml
@@ -1,6 +1,6 @@
 - type: radioChannel
-  id: Botic
-  name: ботический
+  id: ADTSilicon
+  name: Синтетики
   keycode: 'б'
   frequency: 1300
-  color: "#9966CC"
+  color: "#7df9ff"

--- a/Resources/Prototypes/ADT/KD/Channels/keys/RoboticKey.yml
+++ b/Resources/Prototypes/ADT/KD/Channels/keys/RoboticKey.yml
@@ -1,13 +1,13 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyBotic
-  name: ключ к каналу ботов
-  description: ключ к доступу каналов ботов.
+  name: Ключ к каналу ботов
+  description: Ключ к доступу каналов ботов.
   components:
   - type: EncryptionKey
     channels:
-    - Botic
-    defaultChannel: Botic
+    - ADTSilicon
+    defaultChannel: ADTSilicon
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
     state: robotics_label

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -135,10 +135,10 @@
   - type: MovementIgnoreGravity
   - type: IntrinsicRadioTransmitter
     channels:
-    - Botic
+    - ADTSilicon
   - type: ActiveRadio
     channels:
-    - Botic
+    - ADTSilicon
   - type: Fixtures
     fixtures:
     - shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -75,6 +75,7 @@
       - EncryptionKeyCargo
       - EncryptionKeyEngineering
       - EncryptionKeyMedical
+      - EncryptionKeyBotic
       - EncryptionKeyScience
       - EncryptionKeySecurity
       - EncryptionKeyService


### PR DESCRIPTION
Изменил цвет канала, id и name. Прописал чтобы ключ для канала ботов был в телекомсервере по умолчанию. Не знаю как шёпот дронов перевести на 0101010010101010101101.