### PR TITLE
Фикс режима Ядерных Оперативников и фикс канала юрдепа

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -26,7 +26,7 @@ public sealed class NukeopsRuleComponent : Component
     ///     This INCLUDES the operatives. So a value of 3 is satisfied by 2 players & 1 operative
     /// </summary>
     [DataField("playersPerOperative")]
-    public int PlayersPerOperative = 10;
+    public int PlayersPerOperative = 7;
 
     [DataField("maxOps")]
     public int MaxOperatives = 5;

--- a/Resources/Prototypes/ADT/Catalog/RadioChannels/LawyerChannel.yml
+++ b/Resources/Prototypes/ADT/Catalog/RadioChannels/LawyerChannel.yml
@@ -4,3 +4,4 @@
   keycode: 'ю'
   frequency: 1305
   color: "#c6d2f5"
+  longRange: true

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -14,3 +14,4 @@
     EncryptionKeyScience: 2
     EncryptionKeySecurity: 1
     EncryptionKeyService: 3
+    ADTEncryptionKeyLawyer: 1


### PR DESCRIPTION
Изменил соотношение Ядерных Оперативников на число готовых игроков - 1 на 7 вместо 1 на 10

Каналу ЮрДепа добавил параметр, отвечающий за возможность связи без ключа в телеком-сервере

Добавил один ключ юридического канала в вендомат Главы Персонала