### PR TITLE
Corvax-Resprite-Airlocks

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -40,6 +40,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
         if (TryComp<ApcPowerReceiverComponent>(uid, out var receiverComponent))
         {
             Appearance.SetData(uid, DoorVisuals.Powered, receiverComponent.Powered);
+            Appearance.SetData(uid, DoorVisuals.ClosedLights, true); // Corvax-Resprite-Airlocks
         }
     }
 


### PR DESCRIPTION
Исправлено некорректное отображение слоя BaseUnlit во время state = close_unlit у Airlocks.

Спасибо корваксу за это.