### PR TITLE
исправление ямлинтера

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: BaseItem
   id: GasTankBase
@@ -48,7 +48,7 @@
         Blunt: 10
   - type: PhysicalComposition
     materialComposition:
-      Steel: 400
+      Steel: 300
   - type: StaticPrice
     price: 20
 

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -369,12 +369,12 @@
   materials:
     Steel: 1200
 
-- type: latheRecipe
-  id: BaseMagazinePistol
-  result: MagazinePistol
-  completetime: 2
-  materials:
-    Steel: 150
+#- type: latheRecipe
+#  id: BaseMagazinePistol
+#  result: MagazinePistol
+#  completetime: 2
+#  materials:
+#    Steel: 150
 
 - type: latheRecipe
   id: MagazineRifle
@@ -397,12 +397,12 @@
   materials:
     Steel: 900
 
-#- type: latheRecipe
-#  id: MagazinePistol
-#  result: MagazinePistol
-#  completetime: 2
-#  materials:
-#    Steel: 400
+- type: latheRecipe
+  id: MagazinePistol
+  result: MagazinePistol
+  completetime: 2
+  materials:
+    Steel: 400
 
 - type: latheRecipe
   id: SpeedLoaderMagnum


### PR DESCRIPTION
Исправил ошибку, связанную с рецептами охранного техфаба. 

Исправил то, что через улучшенный техфаб можно было крафтить баллоны за меньшее количество стали, чем они дают при переработке